### PR TITLE
fix ball falling off the right screen

### DIFF
--- a/lib/components/ball.dart
+++ b/lib/components/ball.dart
@@ -30,7 +30,7 @@ class Ball extends CircleComponent with  HasGameRef<BreakoutGame>,  CollisionCal
     velocity = Vector2(vx, vy);
   }
   late Vector2 velocity;
-
+  late final _hitbox;
   bool isCollidedScreenHitboxX = false;
   bool isCollidedScreenHitboxY = false;
 
@@ -45,9 +45,9 @@ class Ball extends CircleComponent with  HasGameRef<BreakoutGame>,  CollisionCal
 
   @override
   Future<void> onLoad() async {
-    final hitbox = CircleHitbox(radius: radius);
+    _hitbox = CircleHitbox(radius: radius);
 
-    await add(hitbox);
+    await add(_hitbox);
 
     return super.onLoad();
   }
@@ -55,6 +55,29 @@ class Ball extends CircleComponent with  HasGameRef<BreakoutGame>,  CollisionCal
   @override
   void update(double dt) {
     position += velocity * dt;
+    final screenSize = gameRef.size;
+    final playerSize = _hitbox.size;
+
+    // Calculate the min and max positions for both X and Y axes
+    final minX = playerSize.x / 2;
+    final maxX = screenSize.x - playerSize.x / 2;
+    final minY = playerSize.y / 2;
+    final maxY = screenSize.y - playerSize.y / 2;
+
+    // Clamp the player's position within the screen boundaries
+    position
+      ..x = position.x.clamp(minX, maxX).toDouble()
+      ..y = position.y.clamp(minY, maxY).toDouble();
+    if (position.x <= minX || position.x >= maxX) {
+      // Reverse the horizontal velocity to make the ball bounce off
+      velocity.x = -velocity.x;
+    }
+
+// Check if the ball hits the Y-axis clamp boundaries
+    if (position.y <= minY || position.y >= maxY) {
+      // Reverse the vertical velocity to make the ball bounce off
+      velocity.y = -velocity.y;
+    }
     super.update(dt);
   }
   Future<void> resetBall() async {
@@ -62,7 +85,7 @@ class Ball extends CircleComponent with  HasGameRef<BreakoutGame>,  CollisionCal
 
     position
       ..x = size.x / 2
-      ..y = size.y /2;
+      ..y = size.y / 2;
 
   }
   @override
@@ -81,21 +104,21 @@ class Ball extends CircleComponent with  HasGameRef<BreakoutGame>,  CollisionCal
       final blockRect = other.toAbsoluteRect();
       FlameAudio.play('collide.wav');
 
-          scoreInstance.incrementScore();
-          // for (final point in intersectionPoints) {
-          //   // if (point.x == brickHitbox.left ) {
-          //   //   velocity.x = -velocity.x;
-          //   // }
-          //   // if (point.x == brickHitbox.right ) {
-          //   //   velocity.x = -velocity.x;
-          //   //
-          //   // }
-          //   // if (point.y == brickHitbox.top ) {
-          //   //   velocity.y = -velocity.y;
-          //   // }
-          //   if (point.y == brickHitbox.bottom)  {
-          //     velocity.y = -velocity.y;
-          //   }
+      scoreInstance.incrementScore();
+      // for (final point in intersectionPoints) {
+      //   // if (point.x == brickHitbox.left ) {
+      //   //   velocity.x = -velocity.x;
+      //   // }
+      //   // if (point.x == brickHitbox.right ) {
+      //   //   velocity.x = -velocity.x;
+      //   //
+      //   // }
+      //   // if (point.y == brickHitbox.top ) {
+      //   //   velocity.y = -velocity.y;
+      //   // }
+      //   if (point.y == brickHitbox.bottom)  {
+      //     velocity.y = -velocity.y;
+      //   }
 
       updateBallTrajectory(collisionPoint, blockRect);
     }
@@ -109,6 +132,7 @@ class Ball extends CircleComponent with  HasGameRef<BreakoutGame>,  CollisionCal
     if (other is ScreenHitbox) {
       final screenHitBox = other.toAbsoluteRect();
       FlameAudio.play('paddle-ball-collide.wav');
+
 
       updateBallTrajectory(collisionPoint, screenHitBox);
     }

--- a/lib/components/breakout_forge2d.dart
+++ b/lib/components/breakout_forge2d.dart
@@ -116,8 +116,8 @@ class BreakoutGame extends FlameGame
     gameState = GameState.running;
 
     _ball.position
-      ..x = size.x / index - _ball.size.x / index
-      ..y = size.y * kBallStartYRatio;
+      ..x = size.x / 2
+      ..y = size.y / 2;
     await add(_ball);
   }
 
@@ -132,8 +132,8 @@ class BreakoutGame extends FlameGame
         (size.x - kBlocksStartXPosition * 2 - kBlockPadding * rows) / rows;
 
     final sizeY = (size.y * kBlocksHeightRatio -
-            kBlocksStartYPosition -
-            kBlockPadding * (cols - 1)) /
+        kBlocksStartYPosition -
+        kBlockPadding * (cols - 1)) /
         cols;
 
     final blocks = List<Brick>.generate(cols * rows, (int index) {
@@ -215,7 +215,7 @@ class BreakoutGame extends FlameGame
     // int i;
     int balls = await Level.getBalls();
     for(int i = 1; i < balls + 1; i++){
-    await resetBall(i);
+      await resetBall(i);
     }
     gameState = GameState.ready;
     // overlays.add('PreGame');
@@ -241,8 +241,8 @@ class BreakoutGame extends FlameGame
     await countdown();
     int balls = await Level.getBalls();
     for(int i = 1; i < balls + 1; i++){
-     print(">>>>>ball $i");
-    await resetBall(i);
+      print(">>>>>ball $i");
+      await resetBall(i);
     }
     FlameAudio.bgm.play('constant.wav');
   }


### PR DESCRIPTION
# ​Fix  ball falling off right side of screen on emulators
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. Previously the ball has been falling off the screen on the right side in emulators but not simulators

​
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
​
## Motivation and Context
1. Improve game experience and functioning


<!--- Why is this change required? What problem does it solve? -->
​
## How Has This Been Tested?
1. Landscape and potrait mode tests on iOS phone
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
​
## Screenshots :

[ballfalling offscreen right.webm](https://github.com/hngx-org/team-empire-breakout/assets/57020210/b4187b4f-804b-4065-98c8-c3c0f7bb494b)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] All new and existing tests passed.


